### PR TITLE
Update registration.php

### DIFF
--- a/components/com_users/controllers/registration.php
+++ b/components/com_users/controllers/registration.php
@@ -89,7 +89,7 @@ class UsersControllerRegistration extends UsersController
 					$message = JText::_('COM_USERS_REGISTRATION_ACL_ADMIN_ACTIVATION');
 				}
 
-				$this->setMessage($message);
+				$this->setMessage($message, 'warning');
 				$this->setRedirect(JRoute::_($loginUrl, false));
 
 				return false;


### PR DESCRIPTION
Pull Request for Issue #23763.

### Summary of Changes

Changed type of message from default (message) to warning.

### Testing Instructions

Set administrator confirmation to required, when new users are registering.
* Register a new arbitrary user.
* Log out of all the Joomla frontend.
* Wait for the activation e-mail and activate the account by clicking on the link.

### Expected result

A Warning (yellow) message appears. The action hasn't been accomplished yet. (Please log in to confirm that you are authorised to activate new accounts.)

### Actual result

A green (successful event) message appears. The text is great and valid, but it is misleading about the event -- action has to be taken.

### Documentation Changes Required

IDK about any